### PR TITLE
Added ability to configure and use reuseAddr for use on local machine

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,6 +25,7 @@ var DEFAULT_TIMEOUT = 1000;
 var DEFAULT_INTERVAL = 3000;
 var DEFAULT_DGRAM_TYPE = 'udp4'; // could also be 'udp6'
 var GLOBAL_EVENT_NAME = 'MessageBus';
+var DEFAULT_REUSE_ADDR = true;
 
 // We use events and must inherit from events.EventEmitter
 util.inherits(Discovery, events.EventEmitter);
@@ -52,7 +53,8 @@ function Discovery(options) {
     // Create a dgram socket and bind it
     self.dgramType = (options && options.dgramType) ?
                       options.dgramType.toLowerCase() : DEFAULT_DGRAM_TYPE;
-    self.socket = dgram.createSocket(self.dgramType);
+    self.reuseaddr = (options && options.reuseaddr) ? options.reuseaddr : DEFAULT_REUSE_ADDR;
+    self.socket = dgram.createSocket({type: self.dgramType, reuseAddr: self.reuseaddr});
     self.port = (options && options.port) ? options.port : DEFAULT_UDP_PORT;
     self.bindAddr = (options && options.bindAddr) ? options.bindAddr :
                      undefined;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "udp-discovery",
-  "version": "0.0.4",
+  "name": "udp-discovery-2",
+  "version": "0.0.5",
   "description": "Provides zero-config discovery service using broadcast UDP.",
   "main": "index.js",
   "scripts": {
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/stdarg/udp-discovery.git"
+    "url": "git://github.com/escalion/udp-discovery.git"
   },
   "keywords": [
     "discovery",
@@ -18,7 +18,7 @@
     "multicast",
     "tcp"
   ],
-  "author": "Edmond Meinfelder",
+  "author": "Edmond Meinfelder, Ryan Pannell",
   "license": "MIT",
   "dependencies": {
     "debug": "0.7.4",


### PR DESCRIPTION
Added the argument to use reuseAddr (default: true) with createSocket to allow a user to test code on a local machine by not locking the port in use.